### PR TITLE
GIBS-528: Updated to GDAL version 1.11.0

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-GDAL_VERSION=1.10.1
+GDAL_VERSION=1.11.0
 GDAL_ARTIFACT=gdal-$(GDAL_VERSION).tar.gz
 GDAL_HOME=http://download.osgeo.org/gdal
 GDAL_URL=$(GDAL_HOME)/$(GDAL_VERSION)/$(GDAL_ARTIFACT)
@@ -59,12 +59,12 @@ build/gdal/swig/python/GNUmakefile: deploy/gibs-gdal/python-install.patch
 		patch -p0 < ../../deploy/gibs-gdal/python-install.patch )
 # 	Use external libtool
 	sed -i 's|@LIBTOOL@|/usr/bin/libtool|g' build/gdal/GDALmake.opt.in
-	
+
 #   Build MRF into GDAL
 	sed -i 's|GDAL_FORMATS = |GDAL_FORMATS = mrf |g' build/gdal/GDALmake.opt.in
 	sed -i -e'/^CPL_C_START/a void CPL_DLL GDALRegister_mrf(void);' build/gdal/gcore/gdal_frmts.h
 	sed -i -e'/AutoLoadDrivers/a #ifdef FRMT_mrf\n    GDALRegister_mrf();\n#endif' build/gdal/frmts/gdalallregister.cpp
-	
+
 #	Patch gcore/overview.cpp	
 	( cd build/gdal/gcore ; \
 		patch < ../../../deploy/gibs-gdal/overview.patch )
@@ -166,7 +166,7 @@ mod_onearth-install:
 		$(DESTDIR)/$(PREFIX)/share/onearth/layer_config
 	cp -r src/layer_config/schema \
 		$(DESTDIR)/$(PREFIX)/share/onearth/layer_config
-		
+
 	install -m 755 -d $(DESTDIR)/$(PREFIX)/share/onearth/onearth_logs
 	cp -r src/onearth_logs/logs.* \
 		$(DESTDIR)/$(PREFIX)/share/onearth/onearth_logs

--- a/deploy/gibs-gdal/gibs-gdal.spec
+++ b/deploy/gibs-gdal/gibs-gdal.spec
@@ -1,7 +1,7 @@
-%global gdal_version 1.10.1
-%global gdal_release 6%{?dist}
+%global gdal_version 1.11.0
+%global gdal_release 1%{?dist}
 %global mrf_version 0.4.0
-%global mrf_release 1%{?dist}
+%global mrf_release 2%{?dist}
 
 Name:		gibs-gdal
 Version:	%{gdal_version}
@@ -140,6 +140,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Fri Jul 18 2014 Mike McGann <mike.mcgann@nasa.gov> - 1.11.0-1
+- New upstream GDAL version
+
 * Wed Apr 30 2014 Joe T. Roberts <joe.t.roberts@jpl.nasa.gov> - 1.10.1-5
 - Changed MRF version to 0.3.1
 


### PR DESCRIPTION
Verified that an image was properly generated using MapServer compiled against version GDAL 1.11.0 with MRF support. 
