### PR TITLE
Fix gdal_merge command for mrfgen with mrf_merge true

### DIFF
--- a/src/mrfgen/mrfgen.py
+++ b/src/mrfgen/mrfgen.py
@@ -336,6 +336,8 @@ def gdalmerge(mrf, tile, extents, target_x, target_y, mrf_blocksize, xmin, ymin,
         if nodata != "":
             gdal_merge_command_list.append('-n')
             gdal_merge_command_list.append(nodata)
+            gdal_merge_command_list.append('-a_nodata')
+            gdal_merge_command_list.append(nodata)
         gdal_merge_command_list.append(mrf)
         gdal_merge_command_list.append(tile)
     else: # use gdalbuildvrt/gdalwarp/gdal_translate for RGBA imagery


### PR DESCRIPTION
Fixes #67 

I added `-a_nodata` to gdal_merge command, this force nodata value of the output file and fix the nodatavalue lost during mrfgen process in case of an insert of a paletted file.