### PR TITLE
Add mrf_sparse config option

### DIFF
--- a/src/mrfgen/mrfgen.py
+++ b/src/mrfgen/mrfgen.py
@@ -1023,7 +1023,7 @@ else:
         else:
             sparse = True
     except:
-        nocopy = True
+        sparse = True
     # merge, defaults to False
     try:
         if get_dom_tag_value(dom, 'mrf_merge') == "false":


### PR DESCRIPTION
Added a new `mrf_sparse` configuration option, defaults to true.  If true, then nothing changes.  If false (and if no_copy==True), then UNIFORM_SCALE is used with no gdaladdo.  This will give us MRFs that are less-sparse (extra overviews).  If "sparse" isn't the right term, I'm fine changing that.  It's just what I selected.

I also replaced `blend` with `merge` in the code since that's the lingo that we use.