### PR TITLE
Updating mrfgen to validate a paletted image against the colormap to …

### DIFF
--- a/src/mrfgen/README.md
+++ b/src/mrfgen/README.md
@@ -96,6 +96,8 @@ Directory paths may be different than the example. Directories that do not exist
 * target_x: The full x output size of the MRF image. target_y is calculated to maintain native aspect ratio if not defined in ```<target_y>```.  ```<outsize>``` may be used to specify both x and y output size as one parameter.  
 * mrf_nocopy: (true/false) Whether the MRF should be generated without GDAL copy. mrf_insert will be used for improved performance if true. Defaults to "true" unless a single global image is used as input.
 * mrf_merge: (true/false) Whether overlapping input images should be merged on a last-in basis when performing inserts. Defaults to "false" for faster performance.
+* mrf_noaddo: (true/false) Don't run gdaladdo if UNIFORM_SCALE has been set. Defaults to "false".
+* mrf_strict_palette: (true/false) Validate that the colors in input files match the MRF colormap. A warning is sent if there are mismatches. Defaults to "false".
 
 These parameters are available but not used in the example above nor necessarily required.
 

--- a/src/mrfgen/mrfgen.py
+++ b/src/mrfgen/mrfgen.py
@@ -1065,14 +1065,14 @@ else:
             merge = True
     except:
         merge = False
-    # strict, defaults to False
+    # strict_palette, defaults to False
     try:
-        if get_dom_tag_value(dom, 'mrf_strict') == "false":
-            strict = False
+        if get_dom_tag_value(dom, 'mrf_strict_palette') == "false":
+            strict_palette = False
         else:
-            strict = True
+            strict_palette = True
     except:
-        strict = False
+        strict_palette = False
     # mrf data
     try:
         mrf_data_scale = get_dom_tag_value(dom, 'mrf_data_scale')
@@ -1177,7 +1177,7 @@ log_info_mssg(str().join(['config quality_prec:            ', quality_prec]))
 log_info_mssg(str().join(['config mrf_nocopy:              ', str(nocopy)]))
 log_info_mssg(str().join(['config mrf_noaddo:              ', str(noaddo)]))
 log_info_mssg(str().join(['config mrf_merge:               ', str(merge)]))
-log_info_mssg(str().join(['config mrf_strict:              ', str(strict)]))
+log_info_mssg(str().join(['config mrf_strict_palette:      ', str(strict_palette)]))
 log_info_mssg(str().join(['config mrf_z_levels:            ', zlevels]))
 log_info_mssg(str().join(['config mrf_z_key:               ', zkey]))
 log_info_mssg(str().join(['config mrf_data_scale:          ', mrf_data_scale]))
@@ -1405,7 +1405,7 @@ if mrf_compression_type == 'PPNG' and colormap != '':
 
             # ONEARTH-348 - Validate the palette, but don't do anything about it yet
             # For now, we won't enforce any issues, but will log issues validating imagery
-            if strict:
+            if strict_palette:
                oe_validate_palette_command_list=[script_dir + 'oe_validate_palette.py', '-v ', '-c', colormap, '-i', alltiles[i]]
       
                # Log the oe_validate_palette.py command.

--- a/src/mrfgen/mrfgen_configuration.xsd
+++ b/src/mrfgen/mrfgen_configuration.xsd
@@ -47,6 +47,7 @@ limitations under the License.
         <xs:element ref="mrf_nocopy" minOccurs="0"/>
         <xs:element ref="mrf_noaddo" minOccurs="0"/>
         <xs:element ref="mrf_merge" minOccurs="0"/>
+        <xs:element ref="mrf_strict_palette" minOccurs="0"/>
         <xs:element ref="mrf_z_levels" minOccurs="0"/>
         <xs:element ref="mrf_z_key" minOccurs="0"/>
         <xs:element ref="mrf_data_scale" minOccurs="0"/>
@@ -148,7 +149,8 @@ limitations under the License.
   <xs:element name="mrf_name" type="xs:string" nillable="true"/>
   <xs:element name="mrf_nocopy" type="xs:boolean" nillable="true" default="true"/>
   <xs:element name="mrf_noaddo" type="xs:boolean" nillable="true" default="false"/>
-  <xs:element name="mrf_merge" type="xs:boolean" nillable="true" default="true"/>
+  <xs:element name="mrf_merge" type="xs:boolean" nillable="true" default="false"/>
+  <xs:element name="mrf_strict_palette" type="xs:boolean" nillable="true" default="false"/>
   <xs:element name="mrf_z_levels" type="xs:integer" nillable="true"/>
   <xs:element name="mrf_z_key">
     <xs:complexType>


### PR DESCRIPTION
…start finding issues with imagery we're not aware of.  To do set the stage for this, I've added a mrf_strict flag. Now, if strict, then the paletted image is validated and a WARNING sigevent is logged. But things continue on, as-is.  This will let us start to do some fact finding before actually enforcing strictness.