### PR TITLE
Fixing ignore_colors check

### DIFF
--- a/src/mrfgen/oe_validate_palette.py
+++ b/src/mrfgen/oe_validate_palette.py
@@ -277,7 +277,7 @@ img_color_idx = len(img_colortable)
 
 # Populate initial lists
 for i, img_color in enumerate(img_colortable):
-    if img_color in ignore_colors:
+    if img_color.rgba in ignore_colors:
         if verbose:
             log_info_mssg("Ignoring color: " + ignore_color)
         continue


### PR DESCRIPTION
Test for whether an image color was in the ignore_colors list didn't work because it was comparing against the XML record not rgba value.