### PR TITLE
RGBApng2Palpng transparency fix

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ONEARTH_VERSION=1.3.6
+ONEARTH_VERSION=1.3.7
 
 PREFIX=/usr/local
 LIB_PREFIX=/usr

--- a/deploy/onearth/onearth.spec
+++ b/deploy/onearth/onearth.spec
@@ -1,6 +1,6 @@
 Name:		onearth
-Version:	1.3.6
-Release:	5%{?dist}
+Version:	1.3.7
+Release:	1%{?dist}
 Summary:	Installation packages for OnEarth
 
 License:	ASL 2.0+

--- a/src/empty_tile/oe_generate_empty_tile.py
+++ b/src/empty_tile/oe_generate_empty_tile.py
@@ -47,7 +47,7 @@ from optparse import OptionParser
 import png
 
 toolName = "oe_generate_empty_tile.py"
-versionNumber = "v1.3.6"
+versionNumber = "v1.3.7"
 
 class ColorMap:
     """ColorMap metadata"""

--- a/src/generate_legend/oe_generate_legend.py
+++ b/src/generate_legend/oe_generate_legend.py
@@ -61,7 +61,7 @@ except ImportError:
     ET.register_namespace("","http://www.w3.org/2000/svg")
 
 toolName = "oe_generate_legend.py"
-versionNumber = "v1.3.6"
+versionNumber = "v1.3.7"
 
 class ColorMaps:
     """Collection of ColorMaps"""

--- a/src/layer_config/bin/oe_configure_layer.py
+++ b/src/layer_config/bin/oe_configure_layer.py
@@ -85,7 +85,7 @@ from oe_utils import Environment, get_environment, sigevent, log_info_mssg, log_
 reload(sys)
 sys.setdefaultencoding('utf8')
 
-versionNumber = '1.3.6'
+versionNumber = '1.3.7'
 current_conf = None
 
 

--- a/src/mrfgen/RGBApng2Palpng.c
+++ b/src/mrfgen/RGBApng2Palpng.c
@@ -306,8 +306,17 @@ int return_code=0;
     			} while(c != EOF);;
     		    fclose(lut);
     		    free(buffer);
-    		}
 
+    			// fill in palette with 0,0,0,0 values
+    			for (; j<256; j++) {
+                    dest_pal->red = dest_pal->green = dest_pal->blue = 0;
+                    dest_pal++;  // Not sure  if this is needed
+
+                    redarr[j] = greenarr[j] = bluearr[j] = alphaarr[j] = 0
+
+                    if ( verbose ) fprintf(stderr, "RGBA: %d %d %d %d \n", redarr[j], greenarr[j] , bluearr[j], alphaarr[j]);
+    			}
+    		}
     	} else {
 			for (j=0; j<256; j++)
 			  if ( fscanf(lut, "%d %d %d %d", &red, &green, &blue, &alpha) != 4 ) {

--- a/src/mrfgen/RGBApng2Palpng.c
+++ b/src/mrfgen/RGBApng2Palpng.c
@@ -312,7 +312,7 @@ int return_code=0;
                     dest_pal->red = dest_pal->green = dest_pal->blue = 0;
                     dest_pal++;  // Not sure  if this is needed
 
-                    redarr[j] = greenarr[j] = bluearr[j] = alphaarr[j] = 0
+                    redarr[j] = greenarr[j] = bluearr[j] = alphaarr[j] = 0;
 
                     if ( verbose ) fprintf(stderr, "RGBA: %d %d %d %d \n", redarr[j], greenarr[j] , bluearr[j], alphaarr[j]);
     			}

--- a/src/mrfgen/mrfgen.py
+++ b/src/mrfgen/mrfgen.py
@@ -90,7 +90,7 @@ from decimal import *
 from osgeo import gdal
 from oe_utils import basename, sigevent, log_sig_exit, log_sig_err, log_sig_warn, log_info_mssg, log_info_mssg_with_timestamp, log_the_command, get_modification_time, get_dom_tag_value, remove_file, check_abs_path, add_trailing_slash, verify_directory_path_exists, get_input_files, get_doy_string
 
-versionNumber = '1.3.6'
+versionNumber = '1.3.7'
 oe_utils.basename = None
 
 #-------------------------------------------------------------------------------

--- a/src/mrfgen/oe_validate_palette.py
+++ b/src/mrfgen/oe_validate_palette.py
@@ -57,7 +57,7 @@ import xml.dom.minidom
 import re
 from oe_utils import sigevent, log_sig_exit, log_sig_err, log_sig_warn, log_info_mssg, log_info_mssg_with_timestamp, log_the_command, check_abs_path
 
-versionNumber = '1.3.6'
+versionNumber = '1.3.7'
 colormap_filename = None
     
 class ColorEntry:

--- a/src/scripts/oe_validate_configs.py
+++ b/src/scripts/oe_validate_configs.py
@@ -44,7 +44,7 @@ from oe_utils import *
 from parse_apache_configs import parse_config
 from pyparsing import ParseException
 
-versionNumber = '1.3.6'
+versionNumber = '1.3.7'
 
 # List of allowed directives
 allowed_apache_directives = ["WMTSWrapperRole", "WMTSWrapperEnableTime", "WMTSWrapperMimeType", "Reproject_RegExp", "Reproject_ConfigurationFiles", "tWMS_RegExp", "tWMS_ConfigurationFile"]

--- a/src/scripts/read_idx.py
+++ b/src/scripts/read_idx.py
@@ -39,7 +39,7 @@ import os
 import sys
 import struct
 
-versionNumber = '1.3.6'
+versionNumber = '1.3.7'
     
 #-------------------------------------------------------------------------------   
 

--- a/src/scripts/read_mrf.py
+++ b/src/scripts/read_mrf.py
@@ -41,7 +41,7 @@ import sys
 import struct
 import math
 
-versionNumber = '1.3.6'
+versionNumber = '1.3.7'
     
 #-------------------------------------------------------------------------------   
 

--- a/src/scripts/read_mrfdata.py
+++ b/src/scripts/read_mrfdata.py
@@ -39,7 +39,7 @@ import os
 import sys
 import struct
 
-versionNumber = '1.3.6'
+versionNumber = '1.3.7'
     
 #-------------------------------------------------------------------------------   
 

--- a/src/scripts/twmsbox2wmts.py
+++ b/src/scripts/twmsbox2wmts.py
@@ -85,7 +85,7 @@ def twmsbox2wmts(request_bbox, epsg):
     return "TILECOL=" + str(abs(int(col))) + "\n" + "TILEROW="+str(abs(int(row)))
 
 
-versionNumber = '1.3.6'
+versionNumber = '1.3.7'
 usageText = 'twmsbox2wmts.py --bbox [bbox]'
 
 # Define command line options and args.

--- a/src/scripts/wmts2twmsbox.py
+++ b/src/scripts/wmts2twmsbox.py
@@ -113,7 +113,7 @@ def wmts2twmsbox_scale(scale_denominator, col, row):
     return "Request BBOX: " + format(round(request_minx,10),'f')+","+format(round(request_miny,10),'f')+","+format(round(request_maxx,10),'f')+","+format(round(request_maxy,10),'f')
 
 
-versionNumber = '1.3.6'
+versionNumber = '1.3.7'
 usageText = 'wmts2twmsbox.py --col [TILECOL] --row [TILEROW] --scale_denominator [value] OR --top_left_bbox [bbox]'
 
 # Define command line options and args.

--- a/src/vectorgen/oe_vectorgen.py
+++ b/src/vectorgen/oe_vectorgen.py
@@ -56,7 +56,7 @@ try:
 except:
     sys.exit('ERROR: cannot find GDAL/OGR modules')
 
-versionNumber = '1.3.6'
+versionNumber = '1.3.7'
 basename = None
 
 def geojson2shp(in_filename, out_filename, source_epsg, target_epsg, sigevent_url):


### PR DESCRIPTION
A fix for ONEARTH-635, where the RGBApng2Palpng script was leaving extra values at the end of the colormap with random transparency values.  I now see `RGBA: 0 0 0 0` show up for all unused palette entries.   And then when I run oe_validate_palette, errors I was previously seeing have gone away. 

I also did some updates for the version number since this is off of the v1.3.7 branch.