### PR TITLE
oe_generate_legend UTF-8 parsing update

### DIFF
--- a/src/generate_legend/oe_generate_legend.py
+++ b/src/generate_legend/oe_generate_legend.py
@@ -207,7 +207,7 @@ def parse_colormaps(colormap_location, verbose):
             sys.exit(1)
     
     xmlParser = ET.XMLParser(encoding='utf-8')
-    tree=ET.fromstring(dom.toxml().encode('utf-8'), xmlParser)
+    tree=ET.fromstring(dom.toxml().encode('utf-8'), parser=xmlParser)
     colormaps = []   
     if tree.tag == 'ColorMap':
         colormaps.append(tree)

--- a/src/generate_legend/oe_generate_legend.py
+++ b/src/generate_legend/oe_generate_legend.py
@@ -222,7 +222,7 @@ def parse_colormaps(colormap_location, verbose):
 
 def parse_colormap(colormap_xml, verbose):
     
-    dom = xml.dom.minidom.parseString(ET.tostring(colormap_xml)
+    dom = xml.dom.minidom.parseString(ET.tostring(colormap_xml))
            
     colormap_element = dom.getElementsByTagName("ColorMap")[0]
     try:

--- a/src/generate_legend/oe_generate_legend.py
+++ b/src/generate_legend/oe_generate_legend.py
@@ -206,7 +206,8 @@ def parse_colormaps(colormap_location, verbose):
             raise Exception(msg)
             sys.exit(1)
     
-    tree=ET.fromstring(dom.toxml())
+    xmlParser = ET.XMLParser(encoding='utf-8')
+    tree=ET.fromstring(dom.toxml().encode('utf-8'), xmlParser)
     colormaps = []   
     if tree.tag == 'ColorMap':
         colormaps.append(tree)
@@ -221,7 +222,7 @@ def parse_colormaps(colormap_location, verbose):
 
 def parse_colormap(colormap_xml, verbose):
     
-    dom = xml.dom.minidom.parseString(ET.tostring(colormap_xml))
+    dom = xml.dom.minidom.parseString(ET.tostring(colormap_xml)
            
     colormap_element = dom.getElementsByTagName("ColorMap")[0]
     try:


### PR DESCRIPTION
Update to the oe_generate_legend.py script to better handle parsing of colormaps that use extended ascii characters and need UTF-8 encoding.  (ONEARTH-645)