### PR TITLE
Update error catching for bad JPEG

### DIFF
--- a/src/mrfgen/mrfgen.py
+++ b/src/mrfgen/mrfgen.py
@@ -1600,10 +1600,13 @@ if mrf_compression_type.lower() == 'jpeg' or mrf_compression_type.lower() == 'jp
 
         try:
             img = gdal.Open(tile)
-        except RuntimeError as e:
-            errors += 1
-            log_sig_exit('ERROR', 'Invalid input files', sigevent_url)
-            continue
+            
+            if img is None:
+                errors += 1
+                log_sig_err('Bad JPEG tile detected: ' + tile, sigevent_url)
+                continue
+        except RuntimeError as e:                
+            log_sig_exit('ERROR', 'Failed to execute gdal.Open', sigevent_url)
 
         if img.RasterCount == 1:
             errors += 1

--- a/src/mrfgen/mrfgen.py
+++ b/src/mrfgen/mrfgen.py
@@ -1601,7 +1601,9 @@ if mrf_compression_type.lower() == 'jpeg' or mrf_compression_type.lower() == 'jp
         try:
             img = gdal.Open(tile)
         except RuntimeError as e:
+            errors += 1
             log_sig_exit('ERROR', 'Invalid input files', sigevent_url)
+            continue
 
         if img.RasterCount == 1:
             errors += 1


### PR DESCRIPTION
Ran into an issue while testing 1.3.x in SIT where the `img.RasterCount` failed because `img` was `None`.  That happened because the `gdal.Open(tile)` failed, but then the code kept going.  Probably want to `continue` after that failure... and also increase the error count.