### PR TITLE
NearNb vs NNb update

### DIFF
--- a/src/mrfgen/mrfgen.py
+++ b/src/mrfgen/mrfgen.py
@@ -683,7 +683,7 @@ def run_mrf_insert(tiles, mrf, insert_method, resize_resampling, target_x, targe
     Arguments:
         tiles -- List of tiles to insert
         mrf -- An existing MRF file
-        insert_method -- The resampling method to use {Avg, NearNb}
+        insert_method -- The resampling method to use {Avg, NNb}
         resize_resampling -- The resampling method to use for gdalwarp
         target_x -- The target resolution for x
         target_y -- The target resolution for y
@@ -1945,7 +1945,7 @@ remove_file(vrt_filename)
 # Check if this is an MRF insert update, if not then regenerate a new MRF
 mrf_list = []
 if overview_resampling[:4].lower() == 'near':
-    insert_method = 'NearNb'
+    insert_method = 'NNb'
 else:
     insert_method = 'Avg'
 

--- a/src/mrfgen/mrfgen.py
+++ b/src/mrfgen/mrfgen.py
@@ -1944,7 +1944,7 @@ remove_file(vrt_filename)
 
 # Check if this is an MRF insert update, if not then regenerate a new MRF
 mrf_list = []
-if overview_resampling[:4].lower() == 'near':
+if overview_resampling[:4].lower() == 'near' or overview_resampling == 'NNb':
     insert_method = 'NNb'
 else:
     insert_method = 'Avg'

--- a/src/mrfgen/mrfgen_configuration.xsd
+++ b/src/mrfgen/mrfgen_configuration.xsd
@@ -106,8 +106,6 @@ limitations under the License.
         <xs:enumeration value="average_mp"/>
         <xs:enumeration value="average_magphase"/>
         <xs:enumeration value="mode"/>
-        <xs:enumeration value="Avg"/>
-        <xs:enumeration value="NearNb"/>
       </xs:restriction>
     </xs:simpleType>
   </xs:element>


### PR DESCRIPTION
The MUG says NNB vs NearNB... so making that quick change.
Also, we don't typically provide 'Avg' or 'NearNB' as the overview_resampling... and I don't know if gdaladdo supports it (CLI help doesn't mention it).  Internally, mrfgen will set the insert_method for mrf_insert accordingly.