### PR TITLE
Enable GetLegendGraphic for vector layers

### DIFF
--- a/src/layer_config/bin/oe_configure_layer.py
+++ b/src/layer_config/bin/oe_configure_layer.py
@@ -3105,8 +3105,8 @@ for conf in conf_files:
                 mapfile.write("\t\t\"wms_style_default_legendurl_href\"\t\"" + legendUrl_png_h_url + "\"\n")
 
             if vectorType:
-                mapfile.write(
-                    '\t\t"wfs_getfeature_formatlist"\t\t"geojson,csv"\n')
+                mapfile.write('\t\t"wms_enable_request"\t\t"GetLegendGraphic"\n')
+                mapfile.write('\t\t"wfs_getfeature_formatlist"\t\t"geojson,csv"\n')
                 mapfile.write('\t\t"gml_include_items"\t\t"all"\n')
 
             mapfile.write("\tEND\n")


### PR DESCRIPTION
Enable GetLegendGraphic for vector layers in non-reprojected mapfile configurations. (ONEARTH-624)