### PR TITLE
Remote GC Hack

### DIFF
--- a/src/scripts/oe_configure_remote_layers.py
+++ b/src/scripts/oe_configure_remote_layers.py
@@ -117,7 +117,7 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
         if email_recipient == '':
             mssg = 'No email recipient provided for notifications in get_remote_layers.'
             log_sig_err(mssg, sigevent_url)
-            
+
     # Check to see if we want to rewrite locations
     try:
         srcLocationRewrite = dom.getElementsByTagName('SrcLocationRewrite')[0]
@@ -149,6 +149,7 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
     print('Excluding layers:')
     print('\n'.join(exclude_layers))
 
+    remote_gc = None
     if(wmts):
         try:
             wmts_getcapabilities = get_dom_tag_value(dom, 'SrcWMTSGetCapabilitiesURI')
@@ -158,7 +159,7 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
         # Download and parse GetCapabilites XML
         try:
             print('\nLoading layers from ' + wmts_getcapabilities)
-            
+
             r = requests.get(wmts_getcapabilities)
             remote_gc = r.contents
             if r.status_code != 200:
@@ -168,12 +169,16 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
             try:
                 # Drop down to requesting via curl to deal with some issues in Python 2.6 and SSL/TLS validation
                 temp_file = "wmts_gc_{0}.xml".format(hashlib.md5(str(random.random())).hexdigest().strip()[0:4])
-                subprocess.call(['curl', '-o', temp_file, wmts_getcapabilities])
+                p = subprocess.Popen(['curl', '-o', temp_file, wmts_getcapabilities], stderr=subprocess.PIPE)
+
+                stderr = p.communicate()
+                if stderr: print(stderr)
+
                 with open(temp_file) as f:
                     remote_gc = f.read()
                 etree.fromstring(remote_gc)
                 os.remove(temp_file)
-                
+
             except Exception:
                 log_sig_err('Can\'t download WMTS GetCapabilities from URL: ' +
                             wmts_getcapabilities, sigevent_url)
@@ -208,6 +213,8 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
     else:
         print('\nSkipping WMTS')
 
+    remote_gc  = None
+    remote_gts = None
     if(twms):
         # TWMS GetCapabilities
         try:
@@ -227,7 +234,11 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
             try:
                 # Drop down to requesting via curl to deal with some issues in Python 2.6 and SSL/TLS validation
                 temp_file = "twms_gc_{0}.xml".format(hashlib.md5(str(random.random())).hexdigest().strip()[0:4])
-                subprocess.call(['curl', '-o', temp_file, twms_getcapabilities])
+                p = subprocess.Popen(['curl', '-o', temp_file, twms_getcapabilities], stderr=subprocess.PIPE)
+
+                stderr = p.communicate()
+                if stderr: print(stderr)
+
                 with open(temp_file) as f:
                     remote_gc = f.read()
                 etree.fromstring(remote_gc)
@@ -235,7 +246,7 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
 
             except Exception:
                 log_sig_err('Can\'t download TWMS GetCapabilities from URL: ' +
-                        twms_getcapabilities, sigevent_url)
+                            twms_getcapabilities, sigevent_url)
 
         # Get the layers from the source GC file
         try:
@@ -265,7 +276,7 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
 
         # TWMS GetTileService
         try:
-            twms_gettileservice = get_dom_tag_value(dom, 'SrcTWMSGetTileServiceURI') 
+            twms_gettileservice = get_dom_tag_value(dom, 'SrcTWMSGetTileServiceURI')
         except IndexError:
             mssg = 'SrcTWMSGetTileServiceURI element is missing in ' + conf
             log_sig_err(mssg, sigevent_url)
@@ -281,7 +292,11 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
             try:
                 # Drop down to requesting via curl to deal with some issues in Python 2.6 and SSL/TLS validation
                 temp_file = "twms_gts_{0}.xml".format(hashlib.md5(str(random.random())).hexdigest().strip()[0:4])
-                subprocess.call(['curl', '-o', temp_file, twms_gettileservice])
+                p = subprocess.Popen(['curl', '-o', temp_file, twms_gettileservice], stderr=subprocess.PIPE)
+
+                stderr = p.communicate()
+                if stderr: print(stderr)
+
                 with open(temp_file) as f:
                     remote_gts = f.read()
                 etree.fromstring(remote_gts)
@@ -330,7 +345,7 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
         except etree.XMLSyntaxError:
             log_sig_err("Can't parse environment config file: {0}".format(
                 environmentConfig), sigevent_url)
-        
+
         mapfile_location = environment_xml.findtext('{*}MapfileLocation')
         if not mapfile_location:
             mssg = 'mapfile creation chosen but no <MapfileLocation> found'
@@ -364,7 +379,7 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
             mssg = 'mapfile creation chosen but no "basename" attribute found for <MapfileConfigLocation>'
             warnings.append(asctime() + " " + mssg)
             log_sig_warn(mssg, sigevent_url)
-            
+
         try:
             wmts_getcapabilities = get_dom_tag_value(dom, 'SrcWMTSGetCapabilitiesURI')
         except IndexError:
@@ -401,12 +416,12 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
                     static = False
                 src_format = layer.findtext('{*}Format')
                 src_title = layer.findtext(ows + 'Title')
-        
+
                 # Get TMSs for this layer and build a config for each
                 tms_list = [elem for elem in tilematrixsets if elem.findtext(
                     ows + 'Identifier') == layer.find('{*}TileMatrixSetLink').findtext('{*}TileMatrixSet')]
                 layer_tilematrixsets = sorted(tms_list, key=get_max_scale_dem)
-        
+
                 #HACK
                 if len(layer_tilematrixsets) == 0:
                     print("No layer_tilematrixsets. Skipping layer: " + identifier)
@@ -430,27 +445,27 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
                                                                        ('{default}', default_datetime)])
                     validation_info = VALIDATION_TEMPLATE.replace(
                         '{default}', default_datetime)
-                
+
                 # If the source EPSG:4326 layer has a legend, then add that to the EPSG:3857 layer also
                 legendUrlElems = []
-                
+
                 for styleElem in layer.findall('{*}Style'):
                     legendUrlElems.extend(styleElem.findall('{*}LegendURL'))
-                
+
                 for legendUrlElem in legendUrlElems:
                     attributes = legendUrlElem.attrib
                     if attributes[xlink + 'role'].endswith("horizontal"):
                         style_info = bulk_replace(STYLE_TEMPLATE, [('{width}', attributes["width"]),
                                                                    ('{height}', attributes["height"]),
                                                                    ('{href}', attributes[xlink + 'href'].replace(".svg",".png"))])
-                
+
                 # Mapserver automatically converts to RGBA and works better if we
                 # specify that for png layers
                 mapserver_bands = 4 if 'image/png' in src_format else 3
-                
+
                 src_crs = layer_tilematrixsets[0].findtext('{*}SupportedCRS')
                 src_epsg = get_epsg_code_for_proj_string(src_crs)
-                
+
                 target_bbox = map(
                     str, get_bbox_for_proj_string('EPSG:' + src_epsg, get_in_map_units=(src_epsg not in ['4326','3413','3031'])))
                 target_bbox = [target_bbox[1], target_bbox[0], target_bbox[3], target_bbox[2]]
@@ -468,8 +483,8 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
         except etree.XMLSyntaxError:
             log_sig_err('Can\'t parse WMTS GetCapabilities file (invalid syntax): ' +
                         wmts_getcapabilities, sigevent_url)
-            
-        
+
+
 
     return (warnings, errors)
 
@@ -501,7 +516,7 @@ if __name__ == '__main__':
                       action="store_true", dest="debug",
                       default=False, help="Produce verbose debug messages")
     parser.add_option("--create_mapfile", dest="create_mapfile",
-                      default=False, action="store_true", 
+                      default=False, action="store_true",
                       help="Create MapServer configuration.")
 
     # Read command line args.

--- a/src/scripts/oe_configure_remote_layers.py
+++ b/src/scripts/oe_configure_remote_layers.py
@@ -120,7 +120,7 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
         try:
             internal_location = srcLocationRewrite.getAttribute('internal')
             external_location = srcLocationRewrite.getAttribute('external')
-            print('SrcLocationRewrite internal={} external={}\n'.format(internal_location, external_location))
+            print('SrcLocationRewrite internal={0} external={1}\n'.format(internal_location, external_location))
         except Exception, e:
             log_sig_err(str(e), sigevent_url)
     except IndexError:


### PR DESCRIPTION
Because we're running python 2.6 on prem (shame), we're running into issues with SSL/TLS validation of the GITC remote server.  The only way that seems to avoid lots of deep python library hacks is to just drop down to a curl command.  This would _not_ be needed in OnEarth 1.4.x because we'll be on Python 3 (rejoice).