### PR TITLE
Add stroke_color option to generate legend tool

### DIFF
--- a/src/generate_legend/README.md
+++ b/src/generate_legend/README.md
@@ -33,6 +33,11 @@ Generate horizontal PNG legend with discrete values
 oe_generate_legend.py -c onearth/src/colormaps/samples/SampleColorMap_v1.2_Discrete.xml -r horizontal -f png -o sample_discrete.png 
 ```
 
+Generate horizontal PNG legend with discrete values and white text with black stroke
+```
+oe_generate_legend.py -c onearth/src/colormaps/samples/SampleColorMap_v1.2_Discrete.xml -r horizontal -f png -l white -s black -o sample_discrete.png 
+```
+
 Generate vertical SVG (including tooltips) legend with continuous values
 ```
 oe_generate_legend.py -c onearth/src/colormaps/samples/SampleColorMap_v1.2_ContinuousLinear.xml -r vertical -f svg -o sample_continuous.svg

--- a/src/generate_legend/oe_generate_legend.py
+++ b/src/generate_legend/oe_generate_legend.py
@@ -48,6 +48,7 @@ print(mpl.matplotlib_fname())
 from matplotlib import pyplot
 from matplotlib import rcParams
 import matplotlib.pyplot as plt
+import matplotlib.patheffects as path_effects
 from StringIO import StringIO
 #import numpy as np
 import math
@@ -351,7 +352,7 @@ def parse_legend(legend_xml, colormap_entries):
     return legend
     
 
-def generate_legend(colormaps, output, output_format, orientation, label_color, colorbar_only):
+def generate_legend(colormaps, output, output_format, orientation, label_color, colorbar_only, stroke_color):
     
     # set ticklines out
     rcParams['xtick.direction'] = 'out'
@@ -508,6 +509,8 @@ def generate_legend(colormaps, output, output_format, orientation, label_color, 
                     legend.get_frame().set_alpha(0.5)
                 for text in legend.get_texts():
                     text.set_color(label_color)
+                    if stroke_color:
+                        tick.set_path_effects([path_effects.Stroke(linewidth=1, foreground=stroke_color), path_effects.Normal()])
             
             if has_values == True and (colormap.style != "classification" or colormap.legend == None):
                 if colorbar_only:
@@ -532,12 +535,17 @@ def generate_legend(colormaps, output, output_format, orientation, label_color, 
                 for tick in cb.ax.xaxis.get_ticklabels():
                     tick.set_fontsize(8)
                     tick.set_color(label_color)
+                    if stroke_color:
+                        tick.set_path_effects([path_effects.Stroke(linewidth=1, foreground=stroke_color), path_effects.Normal()])
                     if colorbar_only:
                         tick.set_alpha(0)
                 if colorbar_only: # hide ticks if we want to show colorbar only
                     for tickline in cb.ax.xaxis.get_ticklines():
                         tickline.set_alpha(0)
-
+                elif stroke_color:
+                    for tickline in cb.ax.xaxis.get_ticklines():
+                        tickline.set_path_effects([path_effects.Stroke(linewidth=2, foreground=stroke_color), path_effects.Normal()])
+                cb.ax.tick_params(axis='x', colors=label_color)
                 if colormap.legend != None and len(bounds)>0:
                     if len(cb.ax.get_xticklabels()) > 0:
                         xticklabels = cb.ax.get_xticklabels()
@@ -567,14 +575,18 @@ def generate_legend(colormaps, output, output_format, orientation, label_color, 
                         cb.ax.set_xticklabels(xticklabels)
                 
                 if colormap.units != None and colorbar_only == False:
-                    fig.text(0.5, bottom-height-(0.20/lc), colormap.units, fontsize=10, horizontalalignment='center', color=label_color)
+                    fig_text = fig.text(0.5, bottom-height-(0.20/lc), colormap.units, fontsize=10, horizontalalignment='center', color=label_color)
+                    if stroke_color:
+                        fig_text.set_path_effects([path_effects.Stroke(linewidth=1, foreground=stroke_color), path_effects.Normal()])
                     
             if colormap.title != None and colorbar_only == False:
                 if lc ==1:
                     title_loc = 1-t
                 else:
                     title_loc = bottom+height+(0.07/lc)
-                fig.text(0.5, title_loc, colormap.title, fontsize=10, horizontalalignment='center', weight='bold', color=label_color)
+                    fig_text = fig.text(0.5, title_loc, colormap.title, fontsize=10, horizontalalignment='center', weight='bold', color=label_color)
+                    if stroke_color:
+                        fig_text.set_path_effects([path_effects.Stroke(linewidth=1, foreground=stroke_color), path_effects.Normal()])
                     
         
         else: # default vertical orientation
@@ -616,7 +628,9 @@ def generate_legend(colormaps, output, output_format, orientation, label_color, 
                     legend.get_frame().set_alpha(0.5)
                 for text in legend.get_texts():
                     text.set_color(label_color)
-         
+                    if stroke_color:
+                        text.set_path_effects([path_effects.Stroke(linewidth=1, foreground=stroke_color), path_effects.Normal()])
+
             if has_values == True and (colormap.style != "classification" or colormap.legend == None):
                 if colorbar_only:
                     fig.set_figheight(2.56)
@@ -640,12 +654,17 @@ def generate_legend(colormaps, output, output_format, orientation, label_color, 
                 for tick in cb.ax.yaxis.get_ticklabels():
                     tick.set_fontsize(10)
                     tick.set_color(label_color)
+                    if stroke_color:
+                        tick.set_path_effects([path_effects.Stroke(linewidth=1, foreground=stroke_color), path_effects.Normal()])
                     if colorbar_only:
                         tick.set_alpha(0)
                 if colorbar_only: # hide ticks if we want to show colorbar only
                     for tickline in cb.ax.yaxis.get_ticklines():
                         tickline.set_alpha(0)
-                    
+                elif stroke_color:
+                    for tickline in cb.ax.yaxis.get_ticklines():
+                        tickline.set_path_effects([path_effects.Stroke(linewidth=2, foreground=stroke_color), path_effects.Normal()])
+                cb.ax.tick_params(axis='y', colors=label_color)
                 if colormap.legend != None and len(bounds)>0:
                     if len(cb.ax.get_yticklabels()) > 0:
                         yticklabels = cb.ax.get_yticklabels()
@@ -678,7 +697,9 @@ def generate_legend(colormaps, output, output_format, orientation, label_color, 
                         cb.ax.set_yticklabels(yticklabels)
                 
                 if colormap.units != None and colorbar_only == False:
-                    fig.text(left + (0.08/lc), 0.01, colormap.units, fontsize=10, horizontalalignment='center', color=label_color)
+                    fig_text = fig.text(left + (0.08/lc), 0.01, colormap.units, fontsize=10, horizontalalignment='center', color=label_color)
+                    if stroke_color:
+                        fig_text.set_path_effects([path_effects.Stroke(linewidth=1, foreground=stroke_color), path_effects.Normal()])
 
                                             
             if colormap.title != None and colorbar_only == False:
@@ -704,8 +725,10 @@ def generate_legend(colormaps, output, output_format, orientation, label_color, 
                     for word in title_words[half:len(title_words)]:
                         title = title + word + " "                    
                     colormap.title = title
-                fig.text(title_left, title_top, colormap.title, fontsize=fs, horizontalalignment='center', weight='bold', color=label_color) 
-            
+                fig_text = fig.text(title_left, title_top, colormap.title, fontsize=fs, horizontalalignment='center', weight='bold', color=label_color) 
+                if stroke_color:
+                    fig_text.set_path_effects([path_effects.Stroke(linewidth=1, foreground=stroke_color), path_effects.Normal()])
+    
     fig.savefig(output, transparent=True, format=output_format)
         
     # Add tooltips to SVG    
@@ -822,6 +845,9 @@ parser.add_option('-f', '--format',
 parser.add_option('-l', '--label_color',
                   action='store', type='string', dest='label_color', default = 'black',
                   help='Color of labels. Supported colors: black (default), blue, green, red, cyan, magenta, yellow, white or hexstring')
+parser.add_option('-s', '--stroke_color',
+                  action='store', type='string', dest='stroke_color', default=False,
+                  help='Color of labels stroke. Supported colors: black (default), blue, green, red, cyan, magenta, yellow, white or hexstring')
 parser.add_option('-o', '--output',
                   action='store', type='string', dest='output',
                   help='The full path of the output file')
@@ -863,6 +889,18 @@ if options.label_color:
 else:
     label_color = "black"
 
+# check stroke color
+if options.stroke_color:
+    stroke_color = str(options.stroke_color).lower()
+    if stroke_color not in ["blue","green","red","cyan","magenta","yellow","black","white"]:
+        print "Using custom color " + stroke_color
+        colormatch = re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', stroke_color)
+        if colormatch == False:
+            print "Invalid stroke color"
+            exit()
+else:
+    stroke_color = False
+
 colormaps = []
 # parse colormap file
 try:
@@ -888,7 +926,7 @@ for colormap_xml in colormap_elements:
 
 # generate legend
 try:
-    generate_legend(colormaps, output_location, options.format, options.orientation, label_color, options.colorbar_only)
+    generate_legend(colormaps, output_location, options.format, options.orientation, label_color, options.colorbar_only, stroke_color)
 except IOError,e:
     print str(e)
     exit()

--- a/src/generate_legend/oe_generate_legend.py
+++ b/src/generate_legend/oe_generate_legend.py
@@ -510,7 +510,7 @@ def generate_legend(colormaps, output, output_format, orientation, label_color, 
                 for text in legend.get_texts():
                     text.set_color(label_color)
                     if stroke_color:
-                        tick.set_path_effects([path_effects.Stroke(linewidth=1, foreground=stroke_color), path_effects.Normal()])
+                        text.set_path_effects([path_effects.Stroke(linewidth=1, foreground=stroke_color), path_effects.Normal()])
             
             if has_values == True and (colormap.style != "classification" or colormap.legend == None):
                 if colorbar_only:


### PR DESCRIPTION
This feature adds the  `--stroke_color` option to the `oe_generate_legend.py` tool. The option adds an input stroke color around the label text and ticks in order to provide greater visibility when viewed over light and dark backgrounds.

If no `--stroke_color` is provided, then it will default to `False` and the option will not be used unlike the default `--label_color` which defaults to black.

**Examples:**
- **Existing default black label:**
![sample_discretew](https://user-images.githubusercontent.com/24417194/113350142-10275780-9307-11eb-8032-c1b686cbd81e.png)

- **Changes with white label color and black stroke color:**
![sample_discrete](https://user-images.githubusercontent.com/24417194/113349847-a313c200-9306-11eb-840e-778b1d7637ac.png)

**Additional considerations:**

- There may be room for improvement on the best stroke `linewidth` to use.
Example with stroke `linewidth` of `1`:
![sample_continuousclass100](https://user-images.githubusercontent.com/24417194/113355441-c6db0600-930e-11eb-80cb-b0ba5012a86a.png)
Example with stroke `linewidth` of `0.75`:
![sample_continuousclass075](https://user-images.githubusercontent.com/24417194/113355434-c3e01580-930e-11eb-8ba0-69d50209500f.png)
- Example with white label color and white stroke color. Using the same color for both stroke and label results in a quasi bold text:
![sample_discreted](https://user-images.githubusercontent.com/24417194/113350326-4fee3f00-9307-11eb-93b5-244921a4367e.png)
