### PR TITLE
WMS Extent Coordinate Ordering Issue

### DIFF
--- a/src/scripts/oe_configure_remote_layers.py
+++ b/src/scripts/oe_configure_remote_layers.py
@@ -487,7 +487,6 @@ def get_remote_layers(conf, wmts=True, twms=True, sigevent_url=None, debug=False
 
                 target_bbox = map(
                     str, get_bbox_for_proj_string('EPSG:' + src_epsg, get_in_map_units=(src_epsg not in ['4326','3413','3031'])))
-                target_bbox = [target_bbox[1], target_bbox[0], target_bbox[3], target_bbox[2]]
 
                 mapfile_snippet = bulk_replace(
                     MAPFILE_TEMPLATE, [('{layer_name}', identifier), ('{data_xml}', make_gdal_tms_xml(layer, mapserver_bands, src_epsg)), ('{layer_title}', cgi.escape(src_title)),


### PR DESCRIPTION
Fixing coordinate ordering issue.

Was
```
  <EX_GeographicBoundingBox>
    <westBoundLongitude>-90</westBoundLongitude>
    <eastBoundLongitude>90</eastBoundLongitude>
    <southBoundLatitude>-180</southBoundLatitude>
    <northBoundLatitude>180</northBoundLatitude>
  </EX_GeographicBoundingBox>
  <BoundingBox CRS="EPSG:4326" minx="-180" miny="-90" maxx="180" maxy="90"/>
```

Should be
```
  <EX_GeographicBoundingBox>
    <westBoundLongitude>-180</westBoundLongitude>
    <eastBoundLongitude>180</eastBoundLongitude>
    <southBoundLatitude>-90</southBoundLatitude>
    <northBoundLatitude>90</northBoundLatitude>
  </EX_GeographicBoundingBox>
  <BoundingBox CRS="EPSG:4326" minx="-90" miny="-180" maxx="90" maxy="180"/>
```