### PR TITLE
Added `#include <string.h>` to RGBApng2Palpng.c

### DIFF
--- a/bin/build_el8_rpms_in_docker.sh
+++ b/bin/build_el8_rpms_in_docker.sh
@@ -64,7 +64,7 @@ rm -f /build/dist/*bz2 /build/dist/*debug*
 cp /build/dist/onearth-*.rpm /dist/
 chown "${DOCKER_UID}:${DOCKER_GID}" /dist/onearth-*.rpm
 cd /dist
-tar -cvzf onearth-1.4.0-8.el8.tar.gz *.rpm
+tar -cvzf onearth-1.4.0-9.el8.tar.gz *.rpm
 
 EOS
 chmod +x dist/build_rpms.sh

--- a/deploy/onearth/onearth.spec
+++ b/deploy/onearth/onearth.spec
@@ -1,6 +1,6 @@
 Name:		onearth
 Version:	1.4.0
-Release:	8%{?dist}
+Release:	9%{?dist}
 Summary:	Installation packages for OnEarth
 
 License:	ASL 2.0+
@@ -30,6 +30,7 @@ BuildRequires:	python3-devel
 Requires:	httpd = 2.4.6
 %endif
 %if 0%{?centos} == 8
+BuildRequires:	libarchive => 3.3.3
 Requires:	httpd => 2.4.37
 %endif
 Requires:	gibs-gdal >= 2.4.4

--- a/docker/el8/Dockerfile
+++ b/docker/el8/Dockerfile
@@ -30,5 +30,13 @@ ENV LC_ALL=en_US.UTF-8
 
 RUN sed -i 's/Order allow,deny/Require all granted/g' /etc/httpd/conf.d/onearth-demo.conf
 
+# These httpd conf files currently cause startup issues (needs to be resolved for production)
+RUN mv /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/ssl && \
+	mv /etc/httpd/conf.modules.d/00-proxy.conf /etc/httpd/conf.modules.d/00-proxy && \
+	mv /etc/httpd/conf.modules.d/10-h2.conf /etc/httpd/conf.modules.d/10-h2 && \
+	mv /etc/httpd/conf.modules.d/10-proxy_h2.conf /etc/httpd/conf.modules.d/10-proxy_h2
+
+WORKDIR /usr/share/onearth/
+
 # Start HTTPD server
 CMD sh /usr/local/bin/run-onearth.sh

--- a/docker/el8/run-onearth.sh
+++ b/docker/el8/run-onearth.sh
@@ -12,7 +12,5 @@ echo 'Starting Apache server'
 
 # Tail the apache logs
 exec tail -qF \
-  /etc/httpd/logs/access.log \
-  /etc/httpd/logs/error.log \
   /etc/httpd/logs/access_log \
   /etc/httpd/logs/error_log

--- a/src/layer_config/bin/oe_configure_layer.py
+++ b/src/layer_config/bin/oe_configure_layer.py
@@ -1436,7 +1436,7 @@ if not options.layer_config_filename:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE).stdout
     for line in conf:
-        conf_files.append(line.strip())
+        conf_files.append(line.strip().decode('utf-8'))
 else:
     # use only the solo MRF when specified
     conf_files.append(configuration_filename)

--- a/src/mrfgen/RGBApng2Palpng.c
+++ b/src/mrfgen/RGBApng2Palpng.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <png.h>
 
 /* from gif.h */


### PR DESCRIPTION
Adding `#include <string.h>` fixes the segmentation fault previously encountered when running RGBApng2Palpng.c in CentOS 8.