### PR TITLE
bumped boto3 requirements.txt

### DIFF
--- a/docker/deps/requirements.txt
+++ b/docker/deps/requirements.txt
@@ -2,7 +2,7 @@ requests==2.31.0
 pyaml==21.10.1
 lxml==4.9.2
 pypng==0.20220715.0
-boto3==1.26.42
+boto3==1.34.22
 redis==5.0.0
 urllib3==1.26.18
 setuptools==65.5.1


### PR DESCRIPTION
bumped boto3 from 1.26.42 to 1.34.22

fixes issue #178 

The latest boto3 supports the configuration of endpoint_url from the environment. This helps local development and on-prem deployments.